### PR TITLE
Upgrade to Python 3.x for AWS CLI

### DIFF
--- a/install_awscli.sh
+++ b/install_awscli.sh
@@ -2,12 +2,12 @@
 # vim: et smartindent sr sw=4 ts=4:
 APK_TMP=/var/cache/apk
 GET_PIP=https://bootstrap.pypa.io/get-pip.py
-BUILD_PKGS="openssl-dev wget python-dev ca-certificates"
-PKGS="$BUILD_PKGS python groff less"
+BUILD_PKGS="openssl-dev wget python3-dev ca-certificates"
+PKGS="$BUILD_PKGS python3 groff less"
 echo "INFO $0: installing python, pip and awscli"
 apk --no-cache add --update $PKGS                  \
 && wget -q -T 10 -O /var/tmp/get-pip.py $GET_PIP   \
-&& python /var/tmp/get-pip.py                      \
+&& python3 /var/tmp/get-pip.py                     \
 && pip --no-cache-dir install --upgrade awscli     \
 && apk --no-cache --purge del --update $BUILD_PKGS \
 && rm -rf /var/tmp/get-pip.py $APK_TMP/*           \


### PR DESCRIPTION
Hi there,

Since Python 2.x will reach [the end of its life](https://pythonclock.org/) in about 8 months, I recommend moving to Python 3.x.

I have tested building your [docker_awscli](https://github.com/opsgang/docker_awscli/) image with Python 3.x and it works fine, without further changes.

Let me know if you have any questions!